### PR TITLE
Don't search the entirety of `/opt` because it may be bloated on some systems, causing a really slow search

### DIFF
--- a/src/main/java/com/cleanroommc/javautils/locators/DefaultInstalledJavaLocator.java
+++ b/src/main/java/com/cleanroommc/javautils/locators/DefaultInstalledJavaLocator.java
@@ -81,7 +81,7 @@ public class DefaultInstalledJavaLocator extends AbstractJavaLocator {
     }
 
     private void linux(List<JavaInstall> installs) {
-        for (String directoryName : new String[] { "/usr/java", "/usr/lib/jvm", "/usr/lib32/jvm", "/usr/lib64/jvm", "/usr/local", "/opt", "/app/jdk", "/opt/jdk", "/opt/jdks" }) {
+        for (String directoryName : new String[] { "/usr/java", "/usr/lib/jvm", "/usr/lib32/jvm", "/usr/lib64/jvm", "/usr/local", "/app/jdk", "/opt/jdk", "/opt/jdks" }) {
             deepScanForInstalls(new File(directoryName), installs);
         }
     }


### PR DESCRIPTION
There are already more specific directories like `/opt/jdk` and `/opt/jdks` being searched where a Java installation is more likely to be. It's not very likely a Java installation is elsewhere under `/opt`. Most Linux distros install JVMs under `/usr/lib/jvm` so we can assume the user knows what they're doing if they have Java elsewhere.