### PR TITLE
Add Provisionning locator to JavaUtils

### DIFF
--- a/src/main/java/com/cleanroommc/javautils/locators/CleanroomHomeJavaLocator.java
+++ b/src/main/java/com/cleanroommc/javautils/locators/CleanroomHomeJavaLocator.java
@@ -1,0 +1,28 @@
+package com.cleanroommc.javautils.locators;
+
+import com.cleanroommc.javautils.api.JavaInstall;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+public class CleanroomHomeJavaLocator extends AbstractJavaLocator{
+    @Override
+    protected List<JavaInstall> initialize() {
+        List<JavaInstall> javaInstalls = new ArrayList<>();
+        Path cleanroomJavaDir = userHomePath(".cleanroom/java");
+        if (Files.isDirectory(cleanroomJavaDir)) {
+            try (Stream<Path> entries = Files.list(cleanroomJavaDir)) {
+                entries
+                        .filter(Files::isDirectory)
+                        .forEach(entry -> parseOrLog(javaInstalls, entry));
+            } catch (IOException e) {
+                LOGGER.warn("Error encountered while searching for Cleanroom provisioned Java installs.", e);
+            }
+        }
+        return javaInstalls;
+    }
+}

--- a/src/main/resources/META-INF/services/com.cleanroommc.javautils.spi.JavaLocator
+++ b/src/main/resources/META-INF/services/com.cleanroommc.javautils.spi.JavaLocator
@@ -8,3 +8,4 @@ com.cleanroommc.javautils.locators.JavaHomeJavaLocator
 com.cleanroommc.javautils.locators.MinecraftJavaLocator
 com.cleanroommc.javautils.locators.SDKManProvisionedJavaLocator
 com.cleanroommc.javautils.locators.WindowsRegistryJavaLocator
+com.cleanroommc.javautils.locators.CleanroomHomeJavaLocator


### PR DESCRIPTION
JavaUtils fails to locate Provisionned installs, which makes it fail and sometime crash relauncher. Added CleanroomHomeJavaLocator to the list.